### PR TITLE
windows compiler handholding

### DIFF
--- a/IdleLandsRedux.WebService/Program.cs
+++ b/IdleLandsRedux.WebService/Program.cs
@@ -29,8 +29,8 @@ namespace IdleLandsRedux.WebService
 				var session = Bootstrapper.CreateSession();
 				using (var transaction = session.BeginTransaction()) {
 					DateTime now = DateTime.UtcNow;
-					Player player;
-					StatsObject statsObject;
+					Player player = null;
+					StatsObject statsObject = null;
 
 					try {
 						var users = session.QueryOver<LoggedInUser>()


### PR DESCRIPTION
Prevent windows csharp compiler 4.0.0.0 from complaining about the use
of unassigned local variables.
